### PR TITLE
Using pointer to umlobject when it is not found within the document.

### DIFF
--- a/umbrello/cmds/cmd_baseObjectCommand.cpp
+++ b/umbrello/cmds/cmd_baseObjectCommand.cpp
@@ -33,6 +33,7 @@ namespace Uml
     {
         Q_ASSERT(object);
 
+        m_object = object;
         m_objectId = object->id();
     }
 
@@ -41,7 +42,8 @@ namespace Uml
         UMLDoc *doc = UMLApp::app()->document();
         UMLObject *umlObject = doc->findObjectById(m_objectId);
 
-        //Q_ASSERT(umlObject);
+        if (!umlObject)
+            umlObject = m_object;
 
         return umlObject;
     }

--- a/umbrello/cmds/cmd_baseObjectCommand.h
+++ b/umbrello/cmds/cmd_baseObjectCommand.h
@@ -13,6 +13,7 @@
 
 #include "basictypes.h"
 
+#include <QPointer>
 #include <QUndoCommand>
 
 class UMLObject;
@@ -27,6 +28,7 @@ namespace Uml
 
         protected:
             Uml::ID::Type m_objectId;
+            QPointer<UMLObject> m_object;
 
             void setObject(UMLObject* object);
             UMLObject* object();


### PR DESCRIPTION
BUG: 352633
FIXED-IN: 2.17.90 (KDE Applications 15.11.90)